### PR TITLE
draft: switch to EL9 with the latest rockylinux 9

### DIFF
--- a/aws-batch-using-nice-dcv.dockerfile
+++ b/aws-batch-using-nice-dcv.dockerfile
@@ -1,59 +1,68 @@
-FROM amazonlinux:latest as dcv
+#FROM quay.io/centos/centos:stream9 as dcv
+FROM rockylinux:9 as dcv
 
 # Prepare the container to run systemd inside
 ENV container docker
 
-ARG AWS_REGION=eu-west-1
+
+RUN dnf install -y yum-utils && dnf config-manager --set-enabled crb && dnf clean all
 
 # Install tools
 RUN yum -y install tar sudo less vim lsof firewalld net-tools pciutils \
-                   file wget kmod xz-utils ca-certificates binutils kbd \
+                   file wget kmod xz ca-certificates binutils kbd \
                    python3-pip bind-utils jq bc
 
 # Install awscli and configure region only
 # Note: required to run aws ssm command
-RUN pip3 install awscli 2>/dev/null \
- && mkdir $HOME/.aws \
- && echo "[default]" > $HOME/.aws/config \
- && echo "region =  ${AWS_REGION}" >> $HOME/.aws/config \
- && chmod 600 $HOME/.aws/config
+#RUN pip3 install awscli 2>/dev/null \
+# && mkdir $HOME/.aws \
+# && echo "[default]" > $HOME/.aws/config \
+# && echo "region =  ${AWS_REGION}" >> $HOME/.aws/config \
+# && chmod 600 $HOME/.aws/config
 
 # Install X server and GNOME desktop
 RUN yum -y install glx-utils mesa-dri-drivers xorg-x11-server-Xorg \
-                   xorg-x11-utils xorg-x11-xauth xorg-x11-xinit xvattr \
-                   xorg*fonts* xterm libXvMC mesa-libxatracker freeglut \
-                   gnome-desktop3 gnome-terminal gnome-system-log \
+                   xorg-x11-utils xorg-x11-xauth xorg-x11-xinit  \
+                   xorg*fonts* xterm  mesa-libxatracker freeglut \
+                   gnome-desktop3 gnome-terminal  \
                    gnome-system-monitor nautilus evince gnome-color-manager \
                    gnome-font-viewer gnome-shell gnome-calculator gedit gdm \
-                   metacity gnome-session gnome-classic-session \
-                   gnome-session-xsession gnu-free-fonts-common \
-                   gnu-free-mono-fonts gnu-free-sans-fonts \
-                   gnu-free-serif-fonts desktop-backgrounds-gnome
+                    gnome-session gnome-classic-session \
+                   gnome-session-xsession \
+                   mesa-libGLU
+# todo if necessary find replacements for libXvMC gnome-system-log metacity xvattr,                     gnu-free-fonts-common \
+                                                                #                   gnu-free-mono-fonts gnu-free-sans-fonts \
+                                                                #                   gnu-free-serif-fonts desktop-backgrounds-gnome \
 
-# Install Nvidia Driver, configure Xorg, install NICE DCV server
-RUN wget -q http://us.download.nvidia.com/tesla/418.87/NVIDIA-Linux-x86_64-418.87.00.run -O /tmp/NVIDIA-installer.run \
- && bash /tmp/NVIDIA-installer.run --accept-license \
-                              --no-runlevel-check \
-                              --no-questions \
-                              --no-backup \
-                              --ui=none \
-                              --no-kernel-module \
-                              --no-nouveau-check \
-                              --install-libglvnd \
-                              --no-nvidia-modprobe \
-                              --no-kernel-module-source \
- && rm -f /tmp/NVIDIA-installer.run \
- && nvidia-xconfig --preserve-busid \
- && rpm --import https://d1uj6qtbmh3dt5.cloudfront.net/NICE-GPG-KEY \
+
+# Install Nvidia Driver,
+#RUN wget -q http://us.download.nvidia.com/tesla/418.87/NVIDIA-Linux-x86_64-418.87.00.run -O /tmp/NVIDIA-installer.run \
+# && bash /tmp/NVIDIA-installer.run --accept-license \
+#                              --no-runlevel-check \
+#                              --no-questions \
+#                              --no-backup \
+#                              --ui=none \
+#                              --no-kernel-module \
+#                              --no-nouveau-check \
+#                              --install-libglvnd \
+#                              --no-nvidia-modprobe \
+#                              --no-kernel-module-source \
+# && rm -f /tmp/NVIDIA-installer.run \
+# && nvidia-xconfig --preserve-busid
+
+# configure Xorg, install NICE DCV server
+RUN rpm --import https://d1uj6qtbmh3dt5.cloudfront.net/NICE-GPG-KEY \
  && mkdir -p /tmp/dcv-inst \
  && cd /tmp/dcv-inst \
- && wget -qO- https://d1uj6qtbmh3dt5.cloudfront.net/2020.0/Servers/nice-dcv-2020.0-8428-el7.tgz |tar xfz - --strip-components=1 \
+ && wget -qO- https://d1uj6qtbmh3dt5.cloudfront.net/2023.1/Servers/nice-dcv-2023.1-16388-el9-x86_64.tgz |tar xfz - --strip-components=1 \
  && yum -y install \
-    nice-dcv-gl-2020.0.759-1.el7.i686.rpm \
-    nice-dcv-gltest-2020.0.229-1.el7.x86_64.rpm \
-    nice-dcv-gl-2020.0.759-1.el7.x86_64.rpm \
-    nice-dcv-server-2020.0.8428-1.el7.x86_64.rpm \
-    nice-xdcv-2020.0.296-1.el7.x86_64.rpm
+    nice-dcv-server-2023.1.16388-1.el9.x86_64.rpm \
+    nice-dcv-simple-external-authenticator-2023.1.228-1.el9.x86_64.rpm \
+    nice-dcv-web-viewer-2023.1.16388-1.el9.x86_64.rpm \
+    nice-xdcv-2023.1.565-1.el9.x86_64.rpm \
+ && rm -rf /tmp/dcv-inst
+    # nice-dcv-gl-2023.1.1047-1.el9.x86_64.rpm \
+    # nice-dcv-gltest-2023.1.325-1.el9.x86_64.rpm \
 
 # Define the dcvserver.service
 COPY dcvserver.service /usr/lib/systemd/system/dcvserver.service
@@ -77,10 +86,10 @@ EXPOSE 8443
 
 CMD ["/usr/local/bin/run_script.sh"]
 
-FROM dcv
-# Install Paraview with requirements
-RUN yum -y install libgomp \
- && wget -q -O ParaView-5.8.0-MPI-Linux-Python3.7-64bit.tar.gz "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v5.8&type=binary&os=Linux&downloadFile=ParaView-5.8.0-MPI-Linux-Python3.7-64bit.tar.gz" \
- && mkdir -p /opt/paraview \
- && tar zxf  ParaView-5.8.0-MPI-Linux-Python3.7-64bit.tar.gz --directory /opt/paraview/ --strip 1 \
- && rm -f ParaView-5.8.0-MPI-Linux-Python3.7-64bit.tar.gz
+#FROM dcv
+## Install Paraview with requirements
+#RUN yum -y install libgomp \
+# && wget -q -O ParaView-5.8.0-MPI-Linux-Python3.7-64bit.tar.gz "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v5.8&type=binary&os=Linux&downloadFile=ParaView-5.8.0-MPI-Linux-Python3.7-64bit.tar.gz" \
+# && mkdir -p /opt/paraview \
+# && tar zxf  ParaView-5.8.0-MPI-Linux-Python3.7-64bit.tar.gz --directory /opt/paraview/ --strip 1 \
+# && rm -f ParaView-5.8.0-MPI-Linux-Python3.7-64bit.tar.gz

--- a/run_script.sh
+++ b/run_script.sh
@@ -1,3 +1,77 @@
 #!/bin/bash
-systemctl enable dcvserver
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this
+# software and associated documentation files (the "Software"), to deal in the Software
+# without restriction, including without limitation the rights to use, copy, modify,
+# merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+# PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+function tailDcvLog {
+    echo -n "Waiting for DCV Server to initialize "
+    while [[ ! -f /var/log/dcv/server.log ]] ;do
+        echo -n '.'
+        sleep 3
+    done
+    echo -n '.'
+    sleep 3
+    echo " OK"
+    # uncomment the following line in case you want to see the DCV server log
+     tail -f -n500 /var/log/dcv/server.log
+}
+
+# Configure the NICE DCV License
+ip=""
+if [ "$ip" == "" ] ; then
+  # todo this case isn't working as expected, need a license to continue experiments most likely
+    # We are not on AWS and need a DCV trial license
+    echo "using default trial license"
+    cp /etc/dcv/dcv.conf /etc/dcv/dcv.conf.org
+    cat /etc/dcv/dcv.conf.org | awk '/#license-file/ {print "license-file = \"/usr/share/dcv/license/nice.set\""}; {print}' > /etc/dcv/dcv.conf
+else
+    # on AWS NICE DCV please enable license access to the S3 bucket
+    :
+fi
+
+# Enable the DCV service
+res1=`systemctl enable dcvserver 2>&1`
+echo "dcv startup result = ${res1}"
+echo
+echo "##########################################"
+echo "NICE DCV Container starting up ... "
+echo "##########################################"
+
+echo
+
+# Show DCV Server log in case
+tailDcvLog &
+
+# Setup user and DCV session
+( sleep 10; /usr/local/bin/startup_script.sh ;
+echo
+echo "##########################################"
+echo "Your NICE DCV Session is ready to login to ... "
+echo "##########################################"
+
+echo
+echo The default user name is “user” and the password “dcv” which
+echo can be adapted in the “startup_script.sh”.
+echo
+echo "To connect to DCV you have 2 options: "
+echo
+echo "Web browser: https://External_IP_or_Server_Name:8443 \(you can accept the security exception as there is no SSL certificate installed\) – or –"
+echo
+echo "DCV native client for best performance: Enter “External_IP_or_Server_Name” in the connection field (the portable DCV client can be downloaded here: https://download.nice-dcv.com/)"
+echo
+
+) &
+# echo ">> Exec /usr/sbin/init"
 exec /usr/sbin/init

--- a/startup_script.sh
+++ b/startup_script.sh
@@ -1,13 +1,29 @@
 #!/bin/bash
+
+exec &>> /var/log/startup_script.log
+
 firewall-cmd --zone=public --permanent --add-port=8443/tcp
+firewall-cmd --zone=public --permanent --add-port=8443/udp  # in addition for UDP/QUIC
+
 firewall-cmd --reload
-/usr/local/bin/send_dcvsessionready_notification.sh >/dev/null 2>&1 &
-_username="$(aws secretsmanager get-secret-value --secret-id \
-                   Run_DCV_in_Batch --query SecretString  --output text | \
-                   jq -r  'keys[0]')"
-adduser "${_username}" -G wheel \
- && echo "$(aws secretsmanager get-secret-value --secret-id \
-                   Run_DCV_in_Batch --query SecretString --output text | \
-          sed 's/\"//g' | sed 's/{//' | sed 's/}//')" | chpasswd
-/bin/dcv create-session --owner "${_username}" --user "${_username}" "${_username}session"
+
+set -ex
+
+# AWS="1"
+
+if [ "$AWS" == "1" ] ; then
+    /usr/local/bin/send_dcvsessionready_notification.sh >/dev/null 2>&1 &
+    export AWS_REGION=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region)
+    export AWS_DEFAULT_REGION=${AWS_REGION}
+    _username="$(aws secretsmanager get-secret-value --secret-id \
+                   dcv-cred-user --query SecretString  --output text)"
+    _passwd="$(aws secretsmanager get-secret-value --secret-id \
+                   dcv-cred-passwd --query SecretString  --output text)"
+else
+    _username="user"
+    _passwd="dcv"
+fi
+adduser "${_username}" -G wheel
+echo "${_username}:${_passwd}" |chpasswd
+/usr/bin/dcv create-session --storage-root=%home% --owner "${_username}" --user "${_username}" "${_username}session"
 


### PR DESCRIPTION
# what

- [x] get this building and mostly runable in modern EL context (fedora 39)
   - [x] temp remove nvidia GL stuff (would be nice to have both nvidia and amd variants)
   - [x] get this mostly working in local dev context outside of AWS (adapted from https://www.ni-sp.com/nice-dcv-in-containers/, https://www.ni-sp.com/wp-content/uploads/2019/10/UBUNTU-gpu-dockerfile.docker, https://repost.aws/questions/QUm2jjzH8YQSubxPBQeXwZqg/nice-dcv-docker-container-ubuntu )
   - [ ] add back and update nvidia GPU drivers
     - [ ] either grab t4 driver directly from nvidia (like container image currently does) or use instead grid driver from S3
   - [ ] add amdgpu stuff too (probably bad idea to do in same image as nvidia stuff)
- [ ] add readme which explains expected use and drawbacks
  - [ ] use of --privileged for systemd support
    - [ ] would be nice if we could drop systemd for this use case and just run `dcvserver` directly in startup script 
  - [ ] create-session does not work without temp license or AWS context (IMDS context)  
- [ ]  test in real AWS context
   - [ ] gl
     - note:  may need to use dcv session type `console` instead of `virtual` to avoid llvmpipe software GL rendering
   - [ ] no gl
- [ ] test in rootless context

# why

get this container working on the latest rhel system variant available

open gl accelerated virtual desktop sessions